### PR TITLE
Add line-cloud-path variation

### DIFF
--- a/line_clouds_paths/common.css
+++ b/line_clouds_paths/common.css
@@ -1,0 +1,64 @@
+body, div {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    overflow: hidden;
+    font-family: monospace;
+}
+
+canvas, svg {
+    width: 100%;
+    height: 100%;
+}
+
+#canvas-container {
+    width: calc(100% - 300px);
+    height: 100%;
+    position: absolute;
+    background-color: black;
+}
+#output {
+    height: 100%
+}
+
+#controls {
+    position: absolute;
+    right: 0;
+    width: 300px;
+    height: 100%;
+    background-color: black;
+    border-left: 2px solid grey;
+    z-index: 2;
+    color: white;
+    padding: 12px;
+}
+
+#controls h1 {
+    text-transform: uppercase;
+    border-bottom: 1px solid grey;
+}
+
+.control-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.color-preview {
+    width: 16px;
+    height: 16px;
+    margin-left: 4px;
+}
+
+.action-row {
+    justify-content: flex-end;
+    margin-top: 12px;
+}
+
+input {
+    background-color: #eee;
+    flex-grow: 1;
+    padding: 6px;
+}

--- a/line_clouds_paths/index.html
+++ b/line_clouds_paths/index.html
@@ -1,0 +1,62 @@
+<html>
+    <head>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/seedrandom/3.0.5/seedrandom.min.js">
+        </script>
+        <script src="https://cdn.jsdelivr.net/npm/p5@1.4.1/lib/p5.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/seedrandom/3.0.5/seedrandom.min.js" integrity="sha512-+Ru50BzEpZjlFzVnjSmJfYFPFfY2hS0Kjlu/IvqaJoux7maF5lJrRVUJWJ2LevPls7rd242GLbWEt+zAo4OVVQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
+        <script src="./line_clouds.js"></script>
+        <link rel="stylesheet" href="common.css"> 
+    </head>
+    <body>
+        <main>
+            <div id="canvas-container">
+                <div id="output"></div>
+            </div>
+            <div id="controls">
+                <h1>Simulation</h1>
+                <div class="control-row">
+                    <label>SEED:</label>
+                    <input id="seed" type="text" />
+                </div>
+                <h1>Colours</h1>
+                <div class="control-row">
+                    <label>Color A:</label>
+                    <input id="colorA" type="text" value="#EEEEEE" onchange="updateColor('colorA')" />
+                    <span id="colorAprev" class="color-preview"></span>
+                </div>
+                <div class="control-row">
+                    <label>Color B:</label>
+                    <input id="colorB" type="text" value="#ED4E4E" onchange="updateColor('colorB')" />
+                    <span id="colorBprev" class="color-preview"></span>
+                </div>
+                <div class="control-row">
+                    <label>Color C:</label>
+                    <input id="colorC" type="text" value="#1F2937" onchange="updateColor('colorC')" />
+                    <span id="colorCprev" class="color-preview"></span>
+                </div>
+                <div class="control-row">
+                    <label>Color D:</label>
+                    <input id="colorD" type="text" value="#2DB2B8" onchange="updateColor('colorD')" />
+                    <span id="colorDprev" class="color-preview"></span>
+                </div>
+                <div class="control-row">
+                    <label>Number of paths:</label>
+                    <input id="numPaths" type="text" value="10" onchange="updateNumPaths()" />
+                </div>
+                <!-- <div class="control-row action-row">
+                    <button onclick="pauseAnimation()">Pause</button>
+                    <button onclick="playAnimation()">Play</button>
+                </div> -->
+                <!-- <h1>Visuals</h1>
+                <div class="control-row">
+                    <label>LINE_WIDTH:</label>
+                    <input id="line_width" type="text" onchange="update()"/>
+                </div> -->
+                <div class="control-row action-row">
+                    <button onclick="update()">Generate</button>
+                </div>
+            </div>
+        </main>
+    </body>
+</html>

--- a/line_clouds_paths/line_clouds.js
+++ b/line_clouds_paths/line_clouds.js
@@ -1,0 +1,148 @@
+const unit = 50;
+
+const pathComponents = {
+    "LR": [ "h 50", "h 50", "h 50", "h 50", "h 50" ],
+    "RL": [ "h -50", "h -50", "h -50", "h -50", "h -50" ],
+    "TB": [ "v 50", "v 50", "v 50", "v 50", "v 50" ],
+    "BT": [ "v -50", "v -50", "v -50", "v -50", "v -50" ],
+    "LB": [ "a 45 45 0 0 1 45 45", "a 35 35 0 0 1 35 35", "a 25 25 0 0 1 25 25", "a 15 15 0 0 1 15 15", "a 5 5 0 0 1 5 5" ],
+    "BL": [ "a 5 5 0 0 0 -5 -5", "a 15 15 0 0 0 -15 -15", "a 25 25 0 0 0 -25 -25", "a 35 35 0 0 0 -35 -35", "a 45 45 0 0 0 -45 -45" ],
+    "LT": [ "a 5 5 0 0 0 5 -5", "a 15 15 0 0 0 15 -15", "a 25 25 0 0 0 25 -25", "a 35 35 0 0 0 35 -35", "a 45 45 0 0 0 45 -45" ],
+    "TR": [ "a 5 5 0 0 0 5 5", "a 15 15 0 0 0 15 15", "a 25 25 0 0 0 25 25", "a 35 35 0 0 0 35 35", "a 45 45 0 0 0 45 45" ],
+    "BR": [ "a 45 45 0 0 1 45 -45", "a 35 35 0 0 1 35 -35", "a 25 25 0 0 1 25 -25", "a 15 15 0 0 1 15 -15", "a 5 5 0 0 1 5 -5" ],
+    "TL":  [ "a 45 45 0 0 1 -45 45", "a 35 35 0 0 1 -35 35", "a 25 25 0 0 1 -25 25", "a 15 15 0 0 1 -15 15", "a 5 5 0 0 1 -5 5" ],
+    "RT": [ "a 45 45 0 0 1 -45 -45", "a 35 35 0 0 1 -35 -35", "a 25 25 0 0 1 -25 -25", "a 15 15 0 0 1 -15 -15", "a 5 5 0 0 1 -5 -5" ],
+    "RB": [ "a 5 5 0 0 0  -5  5", "a 15 15 0 0 0 -15 15", "a 25 25 0 0 0 -25 25", "a 35 35 0 0 0 -35 35", "a 45 45 0 0 0 -45 45" ]
+}
+
+
+let numPaths = 10
+
+
+function updateColor (color) {
+    document.getElementById(color + 'prev').style.backgroundColor = document.getElementById(color).value
+}
+
+function updateNumPaths () {
+    numPaths = parseInt(document.getElementById('numPaths').value) || 10
+}
+
+function generate (seed, colors) {
+    const rng = new Math.seedrandom(seed);
+    const cols = colors
+    let colIndex = 0;
+    let background = cols.splice(1+Math.floor(rng()*(cols.length-1)),1)
+    let content = "";
+    // let headings = [10,10,18,10,18,10,10,18,10,3,10,3,10]
+    for (var i=0;i<numPaths;i++) {
+        let x = Math.floor(rng()*2) === 0 ? 0 : 15;
+        let y = Math.floor(rng()*8);
+        // let heading = Math.floor(rng()*2)*2;
+        let heading = (x === 0)?2:0
+        let previousHeading = heading;
+        let col = cols[colIndex]
+
+        let ox = (x+(heading == 2?0:1))*unit
+        let oy = y*unit
+        let backgroundPath = [
+            `M ${ox} ${oy+25}`
+        ]
+        let visited = new Set()
+        let paths = [
+            [`M ${ox} ${oy+5}`],
+            [`M ${ox} ${oy+15}`],
+            [`M ${ox} ${oy+25}`],
+            [`M ${ox} ${oy+35}`],
+            [`M ${ox} ${oy+45}`],
+        ]
+        if (heading === 0) {
+            paths.reverse()
+        }
+        colIndex = (colIndex+1)%cols.length
+        // let col = cols[Math.floor(rng()*cols.length)]
+
+        let step = 0
+        while (x > -1 && x < 17 && y > -1 && y < 9) {
+            let tileType
+            switch(heading) {
+                case 0: tileType = "RL"; break;
+                case 1: tileType = "BT"; break;
+                case 2: tileType = "LR"; break;
+                case 3: tileType = "TB"; break;
+            }
+            previousHeading = heading;
+
+            let r = Math.floor(rng()*20);
+            if (r < 4) {
+                if (heading === 0) tileType = "RB";
+                if (heading === 1) tileType = "BL";
+                if (heading === 2) tileType = "LT";
+                if (heading === 3) tileType = "TR";
+                heading--
+            } else if (r > 15) {
+                if (heading === 0) tileType = "RT";
+                if (heading === 1) tileType = "BR";
+                if (heading === 2) tileType = "LB";
+                if (heading === 3) tileType = "TL";
+                heading++
+            }
+            if (heading === -1) { heading = 3 }
+            if (heading === 4) { heading = 0 }
+
+            // console.log(heading,tileType)
+
+            if (visited.has(`${x},${y}`)) {
+                console.log('collision at',x,y)
+                break
+            }
+
+
+            backgroundPath.push(pathComponents[tileType][2])
+            paths.forEach((p,idx) => {
+                p.push(pathComponents[tileType][idx])
+            })
+            // content += drawTile(tileType,x,y,col,background)
+
+            visited.add(`${x},${y}`)
+            switch(heading) {
+                case 0: x -= 1; break;
+                case 1: y -= 1; break;
+                case 2: x += 1; break;
+                case 3: y += 1; break;
+            }
+        }
+
+        content += `<path d="${backgroundPath.join(" ")}" stroke="${background}" stroke-width="50px" />`
+        paths.forEach(p => {
+            content += `<path d="${p.join(" ")}" stroke="${col}" stroke-width="5px" />`
+        })
+
+
+    }
+
+    
+    const container = document.getElementById('output');
+    container.innerHTML = `<svg viewbox="0 0 800 400" class="h-auto w-full" style="background: ${background}"><g fill="none">${content}</g></svg>`
+}
+
+function update () {
+    const colors = [
+        document.getElementById("colorA").value,
+        document.getElementById("colorB").value,
+        document.getElementById("colorC").value,
+        document.getElementById("colorD").value
+    ]
+    // get colors from input
+    updateColor('colorA')
+    updateColor('colorB')
+    updateColor('colorC')
+    updateColor('colorD')
+
+    const seed = document.getElementById("seed").value
+    generate(seed, colors)
+}
+
+// p5.js setup function
+function setup() {
+    update();
+}


### PR DESCRIPTION
Scratched the itch to rework the original hero generator to try to get rid of the faint lines between the tiles - but at the expense of a single path no longer being able to overlap itself... so not a good solution as-is.

Instead of laying down tiles, this now builds up each line as a continuous path.


<img width="259" alt="image" src="https://user-images.githubusercontent.com/51083/161860266-6eb967e9-0470-4462-b667-40586b88f268.png">

Each path is made up of 5 separate `<path>` elements that make up the foreground you see, plus a 6th `<path>` that follows the same path as the middle foreground path (pointed at in the image) - but with a stroke width of 50px. This draws the solid background behind the foreground paths. This lets one discrete path overlap another.

Where it fails is when a path wants to overlap itself:

<img width="320" alt="image" src="https://user-images.githubusercontent.com/51083/161860635-cd188695-7569-43a9-82f4-be885129c4c1.png">

With the tile approach, we could always draw the background tile over whatever as already there - which could have been the same path or a different one.

But with this approach, the background and foreground paths have to interleave... which you cannot do with svg.

The code in this PR halts a path when it detects it is about to overlap itself. This avoids the ugly overlap, but then loses some of the nice effects the tile-based approach can generate with the paths looping back on themselves.

Also added an option for the number of paths to draw - so you can play with density of the image.

<img width="1394" alt="image" src="https://user-images.githubusercontent.com/51083/161861019-e64265e7-4dc4-4d42-b71b-555155ab4e95.png">

 

